### PR TITLE
control whether to generate Base, Recursive, and/or Corecursive

### DIFF
--- a/examples/Expr.hs
+++ b/examples/Expr.hs
@@ -81,6 +81,16 @@ type Forest a = [Tree a]
 
 makeBaseFunctor ''Tree
 
+-- Test #133
+data FiniteList a = FNil | FCons a !(FiniteList a)
+  deriving (Show)
+
+makeRecursive ''FiniteList
+
+data Stream a = SCons a (Stream a)
+
+makeCorecursive ''Stream
+
 main :: IO ()
 main = do
     let expr2 = ana divCoalg 55 :: Expr Int
@@ -96,6 +106,12 @@ main = do
 
     let expr4 = Node 5 [Node 6 [Node 7 []], Node 8 [Node 9 []]]
     35 @=? cata treeAlg expr4
+
+    let expr5 = FCons 5 (FCons 6 (FCons 7 (FCons 8 (FCons 9 FNil))))
+    35 @=? cata finiteListAlg expr5
+
+    let expr6 = ana (SConsF 1) ()
+    [1,1,1] @=? takeStream 3 expr6
   where
     -- Type signatures to test name generation
     evalAlg :: ExprF Int Int -> Int
@@ -122,3 +138,11 @@ main = do
 
     treeAlg :: TreeF Int Int -> Int
     treeAlg (NodeF r f) = r + sum f
+
+    finiteListAlg :: FiniteListF Int Int -> Int
+    finiteListAlg (FConsF x r) = x + r
+    finiteListAlg FNilF = 0
+
+    takeStream :: Int -> Stream Int -> [Int]
+    takeStream 0 _ = []
+    takeStream n (SCons x xs) = x : takeStream (n-1) xs

--- a/src/Data/Functor/Foldable.hs
+++ b/src/Data/Functor/Foldable.hs
@@ -197,7 +197,7 @@ type family Base t :: * -> *
 -- | A recursive datatype which can be unrolled one recursion layer at a time.
 --
 -- For example, a value of type @[a]@ can be unrolled into a @'ListF' a [a]@.
--- Ifthat unrolled value is a 'Cons', it contains another @[a]@ which can be
+-- If that unrolled value is a 'Cons', it contains another @[a]@ which can be
 -- unrolled as well, and so on.
 --
 -- Typically, 'Recursive' types also have a 'Corecursive' instance, in which

--- a/src/Data/Functor/Foldable/TH.hs
+++ b/src/Data/Functor/Foldable/TH.hs
@@ -11,7 +11,7 @@ module Data.Functor.Foldable.TH
   , baseRulesIncludeCorecursive
   ) where
 
-import Control.Applicative (pure, (<$>))  -- required before ghc-7.10
+import Control.Applicative (Applicative, pure, (<$>))  -- required before ghc-7.10
 import Control.Monad
 import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.Writer (execWriterT, tell)

--- a/src/Data/Functor/Foldable/TH.hs
+++ b/src/Data/Functor/Foldable/TH.hs
@@ -246,14 +246,20 @@ baseRulesField :: Functor f => ((Name -> Name) -> f (Name -> Name)) -> BaseRules
 baseRulesField f rules = (\x -> rules { _baseRulesField = x }) <$> f (_baseRulesField rules)
 
 -- | Whether to generate the base functor type.
+--
+-- Default is to generate it.
 baseRulesIncludeBase :: Functor f => (Bool -> f Bool) -> BaseRules -> f BaseRules
 baseRulesIncludeBase f rules = (\x -> rules { _baseRulesIncludeBase = x }) <$> f (_baseRulesIncludeBase rules)
 
 -- | Whether to generate the Recursive instance.
+--
+-- Default is to generate it.
 baseRulesIncludeRecursive :: Functor f => (Bool -> f Bool) -> BaseRules -> f BaseRules
 baseRulesIncludeRecursive f rules = (\x -> rules { _baseRulesIncludeRecursive = x }) <$> f (_baseRulesIncludeRecursive rules)
 
 -- | Whether to generate the Corecursive instance.
+--
+-- Default is to generate it.
 baseRulesIncludeCorecursive :: Functor f => (Bool -> f Bool) -> BaseRules -> f BaseRules
 baseRulesIncludeCorecursive f rules = (\x -> rules { _baseRulesIncludeCorecursive = x }) <$> f (_baseRulesIncludeCorecursive rules)
 

--- a/src/Data/Functor/Foldable/TH.hs
+++ b/src/Data/Functor/Foldable/TH.hs
@@ -11,6 +11,7 @@ module Data.Functor.Foldable.TH
   , baseRulesIncludeCorecursive
   ) where
 
+import Control.Applicative (pure, (<$>))  -- required before ghc-7.10
 import Control.Monad
 import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.Writer (execWriterT, tell)


### PR DESCRIPTION
`makeBaseFunctor` conveniently generates all of `Base`, `Recursive`, and `Corecursive`. But what if you only want to generate some of those, e.g. because you need to write a non-standard instance by hand, or because your type should only be folded but never unfolded?

`makeBaseFunctorWith` now takes extra options to specify which of the three should be generated. The new `makeRecursive` and `makeCorecursive` are shortcuts for the common case in which `Base` and only one of the two instances are needed.

Fixes #133.