### PR TITLE
work around ghc bug 18320

### DIFF
--- a/recursion-schemes.cabal
+++ b/recursion-schemes.cabal
@@ -93,6 +93,13 @@ library
       Paths_recursion_schemes
 
   ghc-options: -Wall
+  -- PROFILING_ENABLED is a workaround for
+  --   https://gitlab.haskell.org/ghc/ghc/-/issues/18320
+  -- Ignore the "Instead of 'ghc-prof-options: -DPROFILING_ENABLED' use
+  --   'cpp-options: -DPROFILING_ENABLED'" warning, we can't do that because we
+  --   only want the option to be set if profiling is enabled and there is no
+  --   cpp-prof-options.
+  ghc-prof-options: -DPROFILING_ENABLED
   if impl(ghc >= 8.6)
     ghc-options: -Wno-star-is-type
   default-language: Haskell2010

--- a/recursion-schemes.cabal
+++ b/recursion-schemes.cabal
@@ -93,13 +93,6 @@ library
       Paths_recursion_schemes
 
   ghc-options: -Wall
-  -- PROFILING_ENABLED is a workaround for
-  --   https://gitlab.haskell.org/ghc/ghc/-/issues/18320
-  -- Ignore the "Instead of 'ghc-prof-options: -DPROFILING_ENABLED' use
-  --   'cpp-options: -DPROFILING_ENABLED'" warning, we can't do that because we
-  --   only want the option to be set if profiling is enabled and there is no
-  --   cpp-prof-options.
-  ghc-prof-options: -DPROFILING_ENABLED
   if impl(ghc >= 8.6)
     ghc-options: -Wno-star-is-type
   default-language: Haskell2010

--- a/src/Data/Functor/Foldable/TH.hs
+++ b/src/Data/Functor/Foldable/TH.hs
@@ -1,4 +1,15 @@
 {-# LANGUAGE CPP, PatternGuards, Rank2Types #-}
+#if defined(PROFILING_ENABLED)
+-- Workaround for https://gitlab.haskell.org/ghc/ghc/-/issues/18320, a bug
+-- which only occurs when running specific TemplateHaskell code while both
+-- profiling and optimisations are enabled. The code in this file triggers the
+-- bug, so until it is fixed, we work around the issue by disabling
+-- optimisations when profiling is enabled. The code in this file only runs at
+-- compile-time, so this workaround does not affect whether you are profiling
+-- the optimized or non-optimized version of the code _generated_ by
+-- makeBaseFunctor.
+{-# OPTIONS_GHC -O0 #-}
+#endif
 module Data.Functor.Foldable.TH
   ( MakeBaseFunctor(..)
   , BaseRules

--- a/src/Data/Functor/Foldable/TH.hs
+++ b/src/Data/Functor/Foldable/TH.hs
@@ -1,15 +1,13 @@
 {-# LANGUAGE CPP, PatternGuards, Rank2Types #-}
-#if defined(PROFILING_ENABLED)
--- Workaround for https://gitlab.haskell.org/ghc/ghc/-/issues/18320, a bug
--- which only occurs when running specific TemplateHaskell code while both
--- profiling and optimisations are enabled. The code in this file triggers the
--- bug, so until it is fixed, we work around the issue by disabling
--- optimisations when profiling is enabled. The code in this file only runs at
--- compile-time, so this workaround does not affect whether you are profiling
--- the optimized or non-optimized version of the code _generated_ by
--- makeBaseFunctor.
+-- This OPTIONS_GHC line is a workaround for
+-- https://gitlab.haskell.org/ghc/ghc/-/issues/18320, a bug which only occurs
+-- when running specific TemplateHaskell code while both profiling and
+-- optimisations are enabled. The code in this file triggers the bug, so until
+-- it is fixed, we work around the issue by disabling optimisations in this
+-- file. The code in this file only runs at compile-time, the code _generated_
+-- by makeBaseFunctor will still get optimized if the file which calls
+-- makeBaseFunctor is optimized.
 {-# OPTIONS_GHC -O0 #-}
-#endif
 module Data.Functor.Foldable.TH
   ( MakeBaseFunctor(..)
   , BaseRules


### PR DESCRIPTION
The ghc bug https://gitlab.haskell.org/ghc/ghc/-/issues/18320 only occurs when running specific TemplateHaskell code while both profiling and optimizations are enabled. The code in `Data.Functor.Foldable.TH` triggers the bug, so until it is fixed, we work around the issue by disabling optimizations in that file. The code in that file only runs at compile-time, so this workaround does not affect whether the code _generated_ by `makeBaseFunctor` is optimized.

closes #128

Co-authored-by: Oleg Grenrus <oleg.grenrus@iki.fi>