### PR TITLE
Support building with `th-abstraction-0.5.*`

### DIFF
--- a/recursion-schemes.cabal
+++ b/recursion-schemes.cabal
@@ -85,7 +85,7 @@ library
     build-depends:
       template-haskell >= 2.5.0.0 && < 2.20,
       base-orphans     >= 0.5.4   && < 0.9,
-      th-abstraction   >= 0.4     && < 0.5
+      th-abstraction   >= 0.4     && < 0.6
     exposed-modules:
       Data.Functor.Foldable.TH
 


### PR DESCRIPTION
`th-abstraction-0.5.0.0` introduces a `TypeData` constructor for `DatatypeVariant` that characterizes `type data` declarations (introduced in GHC 9.6). Because `type data` data constructors only exist at the type level, not the value level, it doesn't make sense to define `Recursive` or `Corecursive` instances for a `type data` declaration. As a result, this patch makes it an error to use `recursion-schemes`' TH machinery in conjunction with a `type data` declaration.

Fixes #142.