### PR TITLE
Support for template-haskell 2.21 and GHC 9.8

### DIFF
--- a/recursion-schemes.cabal
+++ b/recursion-schemes.cabal
@@ -83,7 +83,7 @@ library
 
   if flag(template-haskell)
     build-depends:
-      template-haskell >= 2.5.0.0 && < 2.21,
+      template-haskell >= 2.5.0.0 && < 2.22,
       th-abstraction   >= 0.4     && < 0.7
     exposed-modules:
       Data.Functor.Foldable.TH

--- a/src/Data/Functor/Foldable/TH.hs
+++ b/src/Data/Functor/Foldable/TH.hs
@@ -35,6 +35,10 @@ import Paths_recursion_schemes (version)
 import Data.Functor.Foldable
 #endif
 
+#if !MIN_VERSION_template_haskell(2,21,0) && !MIN_VERSION_th_abstraction(0,6,0)
+type TyVarBndrVis = TyVarBndrUnit
+#endif
+
 -- $setup
 -- >>> :set -XTemplateHaskell -XTypeFamilies -XDeriveTraversable -XScopedTypeVariables
 -- >>> import Data.Functor.Foldable
@@ -245,14 +249,15 @@ makePrimForDI rules mkInstance'
 
     dataFamilyError = fail "makeBaseFunctor: Data families are currently not supported."
 
-    toTyVarBndr :: Type -> TyVarBndrUnit
+    toTyVarBndr :: Type -> TyVarBndrVis
     toTyVarBndr (VarT n)          = plainTV n
     toTyVarBndr (SigT (VarT n) k) = kindedTV n k
     toTyVarBndr _                 = error "toTyVarBndr"
 
 makePrimForDI' :: BaseRules
                -> Maybe (Name -> [Dec] -> Dec) -- ^ make instance
-               -> Bool -> Name -> [TyVarBndrUnit]
+               -> Bool -> Name
+               -> [TyVarBndrVis]
                -> [ConstructorInfo] -> DecsQ
 makePrimForDI' rules mkInstance' isNewtype tyName vars cons = do
     -- variable parameters


### PR DESCRIPTION
Crucially, we must update some occurrences of TyVarBndrUnit to TyVarBndrVis to reflect the changes due to GHC proposal #425, as suggested in the migration guide to th-abstraction 0.6.