### PR TITLE
Support building with `th-abstraction-0.7.*`

### DIFF
--- a/recursion-schemes.cabal
+++ b/recursion-schemes.cabal
@@ -84,7 +84,7 @@ library
   if flag(template-haskell)
     build-depends:
       template-haskell >= 2.5.0.0 && < 2.22,
-      th-abstraction   >= 0.4     && < 0.7
+      th-abstraction   >= 0.4     && < 0.8
     exposed-modules:
       Data.Functor.Foldable.TH
 


### PR DESCRIPTION
None of the API changes in `th-abstraction-0.7.*` impact how `recursion-schemes` is using the library, so we can simply raise the upper version bounds.

Fixes #158.