### PR TITLE
Sync documentation and definition

### DIFF
--- a/src/Data/Functor/Foldable.hs
+++ b/src/Data/Functor/Foldable.hs
@@ -392,7 +392,7 @@ fold = cata
 --
 -- >>> :{
 -- >>> let ourEnumFromTo :: Int -> Int -> [Int]
--- >>>     ourEnumFromTo lo hi = ana go lo where
+-- >>>     ourEnumFromTo lo hi = unfold go lo where
 -- >>>         go i = if i > hi then Nil else Cons i (i + 1)
 -- >>> :}
 --


### PR DESCRIPTION
I was surprised by the fact that documentation of `unfold` has an example using `ana` instead and doesn't mention that they're the same function.